### PR TITLE
Make a safer use of globals

### DIFF
--- a/m/calfun.m
+++ b/m/calfun.m
@@ -46,9 +46,13 @@ function [y,fvec,G] = calfun(x)
 %     Argonne National Laboratory
 %     Jorge More' and Stefan Wild. January 2008.
 
-global m n nprob probtype fvals fvals_true nfev np
+global BenDFO 
+nprob = BenDFO.nprob;
+n = BenDFO.n;
+m = BenDFO.m;
+probtype = BenDFO.probtype;
 
-n = size(x,1); % Problem dimension
+% n = size(x,1); % Problem dimension
 
 % Restrict domain for some nondiff problems
 xc = x;
@@ -84,9 +88,11 @@ switch probtype
 end
 
 % Update the function value history
-nfev = nfev +1;
-fvals(nfev,np) = y;
-fvals_true(nfev,np) = y;
+if isfield(BenDFO,'nfev')    
+    BenDFO.nfev = BenDFO.nfev +1;
+    BenDFO.fvals(BenDFO.nfev,np) = y;
+    BenDFO.fvals_true(BenDFO.nfev,np) = y;
+end
 
 end
 

--- a/m/testbendfo.m
+++ b/m/testbendfo.m
@@ -12,26 +12,26 @@ numprobs = size(dfo,1);
 probnames = {'smooth','nondiff','wild3','noisy3'};
 
 % Global variables needed
-global m np nprob probtype fvals nfev
+global BenDFO
 
 % Initialize the results cell and fvals array
 Results = cell(length(probnames),numprobs);
 fvals = zeros(1,numprobs);
 
 for np = 1:numprobs
-    nprob = dfo(np,1);
-    n = dfo(np,2);
-    m = dfo(np,3);
-    factor_power = dfo(np,4);
+    BenDFO.nprob = dfo(np,1);
+    BenDFO.n = dfo(np,2);
+    BenDFO.m = dfo(np,3);
+    BenDFO.factor_power = dfo(np,4);
     
     % Obtain starting vector
-    Xs = dfoxs(n,nprob,10^factor_power);
+    Xs = dfoxs(BenDFO.n,BenDFO.nprob,10^BenDFO.factor_power);
     
     % Loop over the 4 problem types
     for p = 1:4
-        probtype = probnames{p};
+        BenDFO.probtype = probnames{p};
         nfev = 0;
-        switch probtype
+        switch BenDFO.probtype
             case 'smooth'
                 [f,fv,G] = calfun(Xs);
                 Results{p,np}.f = f;


### PR DESCRIPTION
For absolute best practices, global variables shouldn't be used. 

This PR proposes a safe-guard with a safer naming convention.

Also notice that `n` was declared as a global variable but overwritten on line 55 of `calfun.m`. 