### PR TITLE
Proposing ensuring calfun inputs are column vectors

### DIFF
--- a/m/calfun.m
+++ b/m/calfun.m
@@ -53,6 +53,8 @@ n = BenDFO.n;
 m = BenDFO.m;
 probtype = BenDFO.probtype;
 
+x = x(:);
+
 eid = 'Input:dimensionIncompatible';
 [nin, jin] = size(x); % Problem dimension
 if nin ~= n || jin ~= 1

--- a/m/calfun.m
+++ b/m/calfun.m
@@ -53,7 +53,9 @@ n = BenDFO.n;
 m = BenDFO.m;
 probtype = BenDFO.probtype;
 
-x = x(:);
+if size(x, 1) == 1
+    x = x(:);
+end
 
 eid = 'Input:dimensionIncompatible';
 [nin, jin] = size(x); % Problem dimension


### PR DESCRIPTION
For convenience with methods (e.g., pounders) that store/pass parameters as column vectors, can we have `calfun` map all `x` to column vectors? 